### PR TITLE
Fix a Natbib warning on default arguments

### DIFF
--- a/thesis-umich.cls
+++ b/thesis-umich.cls
@@ -159,7 +159,7 @@
 \RequirePackage{newtxmath}
 
 % Compress multiple citations
-\RequirePackage{natbib}
+\RequirePackage[square,numbers]{natbib}
 
 % This package allows the ability to create a 'code' environment.
 \RequirePackage{verbatim}


### PR DESCRIPTION
`square` and `numbers` are the default options for Natbib, and there's a warning if the options aren't specified at all.