### PR TITLE
Document font selection in main.tex

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -27,6 +27,8 @@
 %-------------------------------------------------------------------------------
 %--- pdflatex -----
 %\usepackage{times}
+%\usepackage{newtxtext}
+%\usepackage{newtxmath}
 %-------------------------------------------------------------------------------
 
 % If you are using the alpha bibliography style, keep these next three lines in your preamble, so that the references are left-aligned; or, you can comment it out and see what happens

--- a/main.tex
+++ b/main.tex
@@ -6,6 +6,21 @@
 \documentclass[thesis]{thesis-umich}
 \input{packages}
 
+% Set the font styles.
+% The fontspec package works with xelatex, which the tex engine is used by
+% Overleaf.
+\usepackage{fontspec}
+% As of this writing, Rackham does not have strict font requirements, but they
+% suggest "standard fonts" such as Times, Arial, or Times New Roman.
+% Set the below fonts to whatever you like, as long as it's available on your
+% system or in Overleaf.
+% See the Overleaf website for more about font selection:
+% https://www.overleaf.com/learn/latex/XeLaTeX
+% Remove the below \set*font lines to use the default font family (Computer Modern).
+\setromanfont{Times New Roman}
+\setsansfont{Arial}
+\setmonofont{Courier New}
+
 % If you are using the alpha bibliography style, keep these next three lines in your preamble, so that the references are left-aligned; or, you can comment it out and see what happens
 \makeatletter
 \renewcommand{\@biblabel}[1]{[#1]\hfill}

--- a/main.tex
+++ b/main.tex
@@ -6,20 +6,28 @@
 \documentclass[thesis]{thesis-umich}
 \input{packages}
 
-% Set the font styles.
-% The fontspec package works with xelatex, which the tex engine is used by
-% Overleaf.
-\usepackage{fontspec}
+%--- Set the font styles -----
 % As of this writing, Rackham does not have strict font requirements, but they
 % suggest "standard fonts" such as Times, Arial, or Times New Roman.
-% Set the below fonts to whatever you like, as long as it's available on your
-% system or in Overleaf.
-% See the Overleaf website for more about font selection:
-% https://www.overleaf.com/learn/latex/XeLaTeX
-% Remove the below \set*font lines to use the default font family (Computer Modern).
-\setromanfont{Times New Roman}
-\setsansfont{Arial}
-\setmonofont{Courier New}
+% The fonts available to you depend on the typesetting engine you use, e.g.
+% xelatex, lualatex, or pdflatex.
+% The default font family is Computer Modern, which you can override with
+% packages.
+% Set the font to whatever you like, as long as it's compatible with the tex
+% engine you're using.
+% Info from Overleaf on font selection with:
+%     - xelatex: https://www.overleaf.com/learn/latex/XeLaTeX
+%     - pdflatex: https://www.overleaf.com/learn/latex/Font_typefaces
+%-------------------------------------------------------------------------------
+%--- xelatex -----
+%\usepackage{fontspec}
+%\setromanfont{Times New Roman}
+%\setsansfont{Arial}
+%\setmonofont{Courier New}
+%-------------------------------------------------------------------------------
+%--- pdflatex -----
+%\usepackage{times}
+%-------------------------------------------------------------------------------
 
 % If you are using the alpha bibliography style, keep these next three lines in your preamble, so that the references are left-aligned; or, you can comment it out and see what happens
 \makeatletter

--- a/main.tex
+++ b/main.tex
@@ -9,17 +9,17 @@
 %--- Set the font styles -----
 % As of this writing, Rackham does not have strict font requirements, but they
 % suggest "standard fonts" such as Times, Arial, or Times New Roman.
+% In practice, they allow the default LaTeX font (Computer Modern).
 % The fonts available to you depend on the typesetting engine you use, e.g.
 % xelatex, lualatex, or pdflatex.
-% The default font family is Computer Modern, which you can override with
-% packages.
 % Set the font to whatever you like, as long as it's compatible with the tex
 % engine you're using.
-% Info from Overleaf on font selection with:
+% More information from Overleaf on font selection with:
 %     - xelatex: https://www.overleaf.com/learn/latex/XeLaTeX
 %     - pdflatex: https://www.overleaf.com/learn/latex/Font_typefaces
+% See examples below depending on your engine and uncomment lines as needed.
 %-------------------------------------------------------------------------------
-%--- xelatex -----
+%--- xelatex / lualatex -----
 %\usepackage{fontspec}
 %\setromanfont{Times New Roman}
 %\setsansfont{Arial}

--- a/thesis-umich.cls
+++ b/thesis-umich.cls
@@ -155,10 +155,6 @@
 % This is useful for complex figures.
 \RequirePackage{subcaption}
 
-% This changes the font.
-\RequirePackage{newtxtext}
-\RequirePackage{newtxmath}
-
 % Compress multiple citations
 \RequirePackage{natbib}
 


### PR DESCRIPTION
Resolves #6 

Here's an idea where we leave the font as the latex default, but include information about font selection with examples that users can uncomment. Since the fonts available depend on the tex engine, I think maybe we should keep the font selection code commented out. If we set the font to TNR, it won't compile for pdflatex users.