### PR TITLE
Improve list of symbols and add examples

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -89,6 +89,7 @@ Professor Fourth Name in Alphabetical Order
 \showlistofprograms
 \showlistofappendices
 \showlistofacronyms
+\showlistofsymbols
 
 
 % Definition of any acronyms used.
@@ -96,6 +97,13 @@ Professor Fourth Name in Alphabetical Order
 \acronyms{
     \acro{TLA}{Three Letter Acronym}
     \acro{SOA}{Some Other Acronym}
+}
+
+% Definition of any symbols used.
+% To add an symbol, add an \item command with the symbol inside a [] bracket followed by explanations
+\symbols{
+    \item [$\alpha$] The greek letter alpha.
+    \item [$\Gamma$] \blindtext
 }
 
 % Some abstract text

--- a/main.tex
+++ b/main.tex
@@ -83,14 +83,6 @@ Professor Fourth Name in Alphabetical Order
 \chair{Professor First Name}
 %\cochair{Co-chair One \& Co-chair Two}
 
-% Commands to hide or show lists of figures, tables, etc.
-% To hide a list, change the word "show" in the command to "hide".
-\showlistoftables
-\showlistofprograms
-\showlistofappendices
-\showlistofacronyms
-\showlistofsymbols
-
 
 % Definition of any acronyms used.
 % To add an acronym, add an \acro{}{} command on a new line within the \acronyms{} command. For \acro, field 1 is the acronym and field 2 is the corresponding expression. For example: \acro{TLA}{Three Letter Acronym}.
@@ -105,6 +97,15 @@ Professor Fourth Name in Alphabetical Order
     \item [$\alpha$] The greek letter alpha.
     \item [$\Gamma$] \blindtext
 }
+
+% Commands to hide or show lists of figures, tables, etc.
+% To hide a list, change the word "show" in the command to "hide".
+\showlistoftables
+\showlistofprograms
+\showlistofappendices
+\showlistofacronyms
+\hidelistofsymbols
+
 
 % Some abstract text
 \abstract{

--- a/thesis-umich.cls
+++ b/thesis-umich.cls
@@ -182,6 +182,9 @@
 % This package is used for the list of abbreviations
 \RequirePackage{acronym}
 
+% This package is used to support item list customization (for list of symbols)
+\RequirePackage{enumitem}
+
 % This package is for the index, if it is to be used.
 \if@umich@index
  \RequirePackage{makeidx}
@@ -839,7 +842,7 @@
 \newcommand{\showlistofappendices}{\@umich@listofappendicestrue}
 \newcommand{\showlistofabbreviations}{\@umich@listofabbrevstrue}
 \newcommand{\showlistofacronyms}{\@umich@listofacronymstrue}
-\newcommand{\showlistofsymbos}{\@umich@listofsymbolstrue}
+\newcommand{\showlistofsymbols}{\@umich@listofsymbolstrue}
 
 % Commands to hide each of the lists
 \newcommand{\hidelistoffigures}{\@umich@listoffiguresfalse}
@@ -850,7 +853,7 @@
 \newcommand{\hidelistofappendices}{\@umich@listofappendicesfalse}
 \newcommand{\hidelistofabbreviations}{\@umich@listofabbrevsfalse}
 \newcommand{\hidelistofacronyms}{\@umich@listofacronymsfalse}
-\newcommand{\hidelistofsymbos}{\@umich@listofsymbolsfalse}
+\newcommand{\hidelistofsymbols}{\@umich@listofsymbolsfalse}
 
 
 %% ---- TENTS ----------------------------------------------
@@ -1277,9 +1280,9 @@
  \vspace{1ex} %
  % Start the automatic symbols feature.
  \begin{singlespace} %
-  \begin{acronym} %
+  \begin{itemize}[labelwidth={3em}, align=left, leftmargin=3.5em] %
    \@symbols %
-  \end{acronym} %
+  \end{itemize} %
  \end{singlespace} %
 }
 


### PR DESCRIPTION
The original support for the list of symbols is implemented through the `\begin{acrynom}` command, which I have no idea about how to add symbols. I changed the command to `\begin{itemize}` with some customizations, right now the output looks like:

![image](https://github.com/meluso/UMich_Dissertation_Template/assets/9154441/960f6bda-57c4-47c7-855a-5b54848b062d)
