### PR TITLE
Change {loa} to {loapp} for tracking appendices.

### DIFF
--- a/thesis-umich.cls
+++ b/thesis-umich.cls
@@ -1087,7 +1087,7 @@
  \vspace{1ex} %
  % Start the automatic table of contents features.
  \begin{singlespace} %
-  \@starttoc{loa}\if@restonecol\twocolumn\fi %
+  \@starttoc{loapp}\if@restonecol\twocolumn\fi %
  \end{singlespace} %
 }
 
@@ -1126,9 +1126,9 @@
  % Add a bookmark manually.
  \pdfbookmark[0]{#1}{#2} %
  % Add sections to the table of contents.
- \addtocontents{loa}{\setcounter{tocdepth}{1}} %
+ \addtocontents{loapp}{\setcounter{tocdepth}{1}} %
  % Add to the list of appendices rather than toc.
- \addcontentsline{loa}{chapter}{\protect\numberline{\thechapter}\space#1} %
+ \addcontentsline{loapp}{chapter}{\protect\numberline{\thechapter}\space#1} %
  % Save the chapter number.
  \chaptermark{#1} %
  % Add extra space to the lists of figures and tables and maps.
@@ -1152,7 +1152,7 @@
   % Add a bookmark manually.
   \pdfbookmark[1]{#1}{#1} %
   % Add to list of appendices
-  % \addcontentsline{loa}{section}{#1}
+  % \addcontentsline{loapp}{section}{#1}
   % Save the section number
   \sectionmark{#1}
   % Issue the start section command


### PR DESCRIPTION
\usepackage{algorithm} packages already uses {loa} to track list of algorithms. Changing appendix tracking to {loapp} to avoid conflicts.

**Before: conflicts with algorithm package**
![image](https://github.com/user-attachments/assets/7b190d5f-9e0b-4c27-a3d9-f2b3faf799d1)
![image](https://github.com/user-attachments/assets/93c49621-4d52-470d-b6b9-f9003245eb7a)
![image](https://github.com/user-attachments/assets/031d1cdd-575b-4c46-a230-b983c90e3a22)

**After: no more conflicts**
![image](https://github.com/user-attachments/assets/6635e0b7-0149-4cf5-9c2e-d02aa51dbd3b)
