### PR TITLE
[BUG] Heading font size too large, [FEATURE] appendix bookmark, spacing, xcolor fixes

### DIFF
--- a/dissertation.cls
+++ b/dissertation.cls
@@ -346,7 +346,9 @@
   % Force 1.5 spacing for front matter sections
   \onehalfspacing
   % Heading
-  \centerline{\fontsize{16}{16}\bf\uppercase{#1}}
+  \centerline{\fontsize{16}{16}\bf \uppercase{#1}}
+  % Add some space after the title.
+  \vspace{2ex}
   % Insert the text.
   \sloppy #2 %
 }
@@ -502,7 +504,7 @@
  % Use front page styling.
  \frntpg %
  % Larger upper margin for first page of table
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Add the title
  \centerline{\fontsize{16}{16}\bf TABLE OF CONTENTS} %
  % Add some space after the title.
@@ -526,7 +528,7 @@
  % Use front page styling.
  \frntpg %
  % Larger upper margin for first page of table
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Add the title
  \centerline{\fontsize{16}{16}\bf LIST OF FIGURES} %
  % Add some space after the title.
@@ -551,7 +553,7 @@
  % Use front page styling.
  \frntpg %
  % Larger upper margin for first page of table
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Add the title
  \centerline{\fontsize{16}{16}\bf LIST OF TABLES} %
  % Add some space after the title.
@@ -583,7 +585,7 @@
  % Use front page styling.
  \frntpg %
  % Larger upper margin for first page of table
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Add the title
  \centerline{\fontsize{16}{16}\bf LIST OF PROGRAMS} %
  % Add some space after the title.
@@ -611,7 +613,7 @@
  % Use front page styling.
  \frntpg %
  % Larger upper margin for first page of table
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Add the title
  \centerline{\fontsize{16}{16}\bf LIST OF APPENDICES} %
  % Add some space after the title.
@@ -646,11 +648,9 @@
  % Use front page styling.
  \frntpg %
  % Larger upper margin for first page of table
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Add the title
  \centerline{\fontsize{16}{16}\bf LIST OF ACRONYMS} %
- % Add some space after the title.
-%  \vspace{1ex} %
  % Start the automatic abbreviations feature.
  \begin{singlespace} %
   \begin{acronym} %
@@ -682,7 +682,7 @@
  % Use front page styling.
  \frntpg %
  % Larger upper margin for first page of table
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Add the title
  \centerline{\fontsize{16}{16}\bf LIST OF SYMBOLS} %
  % Add some space after the title.
@@ -733,7 +733,7 @@
  % Add this page to the table of contents.
  \phantomsection\addcontentsline{toc}{frontchapter}{Abstract} %
  % Extra vertical space
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Center the title area.
  \begin{center} %
   % Formatting
@@ -806,8 +806,6 @@
 \def\@section@appendix#1{
   % Begin the phantom section to accommodate hyperref package
   \phantomsection
-  % Add a bookmark manually.
-  % \pdfbookmark[1]{#1}{#1} % remove this line to avoid duplicate bookmarks
   % Save the section number
   \sectionmark{#1}
   % Issue the start section command
@@ -860,7 +858,7 @@
 % Change the formatting of the first page of each chapter.
 \renewcommand{\@makechapterhead}[1]{%
  % Insert an extra top margin.
- \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
+ \vspace*{1in}
  % Insert the text
  { %
   % Ensure proper alignment.

--- a/dissertation.cls
+++ b/dissertation.cls
@@ -108,6 +108,12 @@
 % This package allows for appendices after the \appendix command
 \RequirePackage[titletoc]{appendix}
 
+% This package allows for adjusting section title formats
+\RequirePackage{titlesec}
+
+% This package allows for any font size
+\RequirePackage{lmodern}
+
 %% ---- FORMATTING -----------------------------------------------------
 % Set the page style to fancy.
 \pagestyle{fancy}
@@ -340,7 +346,7 @@
   % Force 1.5 spacing for front matter sections
   \onehalfspacing
   % Heading
-  \begin{center}\textbf{\large\uppercase{#1}}\end{center} %
+  \centerline{\fontsize{16}{16}\bf\uppercase{#1}}
   % Insert the text.
   \sloppy #2 %
 }
@@ -498,7 +504,7 @@
  % Larger upper margin for first page of table
  \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
  % Add the title
- \centerline{\large\bf TABLE OF CONTENTS} %
+ \centerline{\fontsize{16}{16}\bf TABLE OF CONTENTS} %
  % Add some space after the title.
  \vspace{2ex} %
  % Start the automatic table of contents features.
@@ -522,7 +528,7 @@
  % Larger upper margin for first page of table
  \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
  % Add the title
- \centerline{\large\bf LIST OF FIGURES} %
+ \centerline{\fontsize{16}{16}\bf LIST OF FIGURES} %
  % Add some space after the title.
  \vspace{1ex} %
  % Start the automatic table of contents features.
@@ -547,7 +553,7 @@
  % Larger upper margin for first page of table
  \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
  % Add the title
- \centerline{\large\bf LIST OF TABLES} %
+ \centerline{\fontsize{16}{16}\bf LIST OF TABLES} %
  % Add some space after the title.
  \vspace{1ex} %
  % Start the automatic table of contents features.
@@ -579,7 +585,7 @@
  % Larger upper margin for first page of table
  \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
  % Add the title
- \centerline{\large\bf LIST OF PROGRAMS} %
+ \centerline{\fontsize{16}{16}\bf LIST OF PROGRAMS} %
  % Add some space after the title.
  \vspace{1ex} %
  % Start the automatic table of contents features.
@@ -607,13 +613,14 @@
  % Larger upper margin for first page of table
  \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
  % Add the title
- \centerline{\large\bf LIST OF APPENDICES} %
+ \centerline{\fontsize{16}{16}\bf LIST OF APPENDICES} %
  % Add some space after the title.
  \vspace{1ex} %
  % Start the automatic table of contents features.
  \begin{singlespace} %
   \@starttoc{loapp}\if@restonecol\twocolumn\fi %
  \end{singlespace} %
+ \addtocontents{loapp}{\hbox{APPENDIX}}
 }
 
 %% ---- LIST OF ACRONYMS -----------------------------------------------
@@ -641,9 +648,9 @@
  % Larger upper margin for first page of table
  \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
  % Add the title
- \centerline{\large\bf LIST OF ACRONYMS} %
+ \centerline{\fontsize{16}{16}\bf LIST OF ACRONYMS} %
  % Add some space after the title.
- \vspace{1ex} %
+%  \vspace{1ex} %
  % Start the automatic abbreviations feature.
  \begin{singlespace} %
   \begin{acronym} %
@@ -677,7 +684,7 @@
  % Larger upper margin for first page of table
  \begin{minipage}{0.8\textwidth} \vspace{1in} \end{minipage} \\ %
  % Add the title
- \centerline{\large\bf LIST OF SYMBOLS} %
+ \centerline{\fontsize{16}{16}\bf LIST OF SYMBOLS} %
  % Add some space after the title.
  \vspace{1ex} %
  % Start the automatic symbols feature.
@@ -730,7 +737,7 @@
  % Center the title area.
  \begin{center} %
   % Formatting
-  \large \bfseries
+  \fontsize{16}{16} \bfseries
   % Add the heading.
   ABSTRACT \\[2ex] %
  \end{center} %
@@ -800,7 +807,7 @@
   % Begin the phantom section to accommodate hyperref package
   \phantomsection
   % Add a bookmark manually.
-  \pdfbookmark[1]{#1}{#1} %
+  % \pdfbookmark[1]{#1}{#1} % remove this line to avoid duplicate bookmarks
   % Save the section number
   \sectionmark{#1}
   % Issue the start section command
@@ -809,7 +816,7 @@
     {0pt} %
     {-3.5ex plus -1ex minus -0.2ex} %
     {2.3ex plus 0.2ex} %
-    {\normalfont\Large\bfseries}
+    {\normalfont\fontsize{16}{16}\bfseries}
     {#1} % Add the section title text
   }
 
@@ -818,7 +825,7 @@
 \let\@tex@bibliography\bibliography
 
 % Change the bibliography header.
-\renewcommand*{\bibname}{\centerline{\large BIBLIOGRAPHY}}
+\renewcommand*{\bibname}{\centerline{\normalfont\fontsize{16}{16}\bfseries BIBLIOGRAPHY}}
 
 % Create a new command for the bibliography.
 \renewcommand*{\bibliography}[1]{
@@ -861,15 +868,18 @@
   % Check for chapter overflow.
   \ifnum \c@secnumdepth >\m@ne %
    % CHAPTER and number
-   \centerline{\Large\bf \@chapapp{} \thechapter} \par %
+   \centerline{\fontsize{16}{16}\bf \@chapapp{} \thechapter} \par %
    % Vertical space
    \vskip 0.3in \fi %
    % Insert the title of the chapter.
-   \begin{center} \LARGE\bf #1 \end{center} %
+   \begin{center} \fontsize{16}{16}\bf #1 \end{center} %
    % Vertical space after the title
    \nobreak \vskip 0.3in %
  } %
 }
+
+%% ---- SECTION HEADINGS -----------------------------------------------
+\titleformat{\section}{\vskip 0.5em\fontsize{16}{16}\bfseries}{\thesection}{1em}{}
 
 %% ---- SPACING --------------------------------------------------------
 % This fixes the spacing below captions, which by default can be small.
@@ -877,7 +887,7 @@
 
 %% ---- LINKS ----------------------------------------------------------
 % This loads a package that allows extra colors for links.
-\RequirePackage[usenames,dvipsnames]{xcolor}
+\RequirePackage[dvipsnames]{xcolor}
 
 % This will make labels and references hyperlinks.
 \RequirePackage{hyperref, href-ul}
@@ -901,7 +911,7 @@
  % Insert a title page.
  \titlepage %
  % Change the PDF title.
- \hypersetup{pdftitle=\inserttitle} %
+ \hypersetup{pdftitle=\inserttitle,pdfauthor=\insertauthor} %
  % Insert the frontispiece if there is one.
  \if@umich@frontispiece\frontispiecepage\fi %
  % Insert the copyright page if there is one.

--- a/dissertation.cls
+++ b/dissertation.cls
@@ -735,12 +735,9 @@
  % Extra vertical space
  \vspace*{1in}
  % Center the title area.
- \begin{center} %
-  % Formatting
-  \fontsize{16}{16} \bfseries
-  % Add the heading.
-  ABSTRACT \\[2ex] %
- \end{center} %
+ \centerline{\fontsize{16}{16}\bf ABSTRACT} %
+ % Add some space after the title.
+ \vspace{2ex} %
  % Insert the abstract text.
  \onehalfspacing %
  % Insert the text.
@@ -823,7 +820,7 @@
 \let\@tex@bibliography\bibliography
 
 % Change the bibliography header.
-\renewcommand*{\bibname}{\centerline{\normalfont\fontsize{16}{16}\bfseries BIBLIOGRAPHY}}
+\renewcommand*{\bibname}{\vspace{0.35em}\centerline{\normalfont\fontsize{16}{16}\bfseries BIBLIOGRAPHY}\vspace{-0.35em}}
 
 % Create a new command for the bibliography.
 \renewcommand*{\bibliography}[1]{


### PR DESCRIPTION
1. removed duplicated appendix section PDF bookmark, 
2. adjusted heading font size (<=16 pt, it was 17.28 pt for \Large) to follow the format guideline, 
3. adjusted space below "List of Acronyms" heading
4. removed "usenames" arguments in xcolor to remove warning

Based on the previous pull request, I removed "List of Algorithms", and the left edits are to solve format issue and template warning